### PR TITLE
Upgrade dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,15 +17,10 @@ module.exports = function(options) {
     try { compiled = Emblem.precompile(Handlebars, contents, compilerOptions).toString(); }
     catch (err) { this.emit('error', err); }
     if (compiled) {
+      compiled = 'Handlebars.template('+compiled+')';
       file.contents = new Buffer(compiled);
       file.path = gutil.replaceExtension(file.path, '.js');
-      file.defineModuleOptions = {
-        require: { Handlebars: 'handlebars' },
-        context: {
-          handlebars: "Handlebars.template(<%= contents %>)"
-        },
-        wrapper: "<%= handlebars %>"
-      };
+
       this.queue(file);
     }
   });

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "Emblem.js plugin for gulp",
   "main": "index.js",
   "dependencies": {
-    "through": "~2.3.0",
-    "handlebars": "~1.3.0",
-    "emblem": "~0.3.9",
-    "gulp-util": "~2.2.0"
+    "through": "^2.3.6",
+    "handlebars": "^2.0.0",
+    "emblem": "^0.4.0",
+    "gulp-util": "^3.0.4"
   },
   "devDependencies": {
-    "should": "~2.1.1",
-    "mocha": "~1.17.0"
+    "should": "^5.0.1",
+    "mocha": "^2.1.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha"

--- a/test/expected/Basic.js
+++ b/test/expected/Basic.js
@@ -1,3 +1,0 @@
-{"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  return "Basic template";
-  },"useData":true}

--- a/test/expected/Basic.js
+++ b/test/expected/Basic.js
@@ -1,8 +1,3 @@
-function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+{"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "Basic template";
-  }
+  },"useData":true}

--- a/test/main.js
+++ b/test/main.js
@@ -8,6 +8,7 @@ require('mocha');
 
 var getFixture = function(filePath) {
   filePath = path.join('test', 'fixtures', filePath);
+
   return new gutil.File({
     path: filePath,
     cwd: path.join('test', 'fixtures'),
@@ -32,11 +33,13 @@ describe('gulp-emblem', function() {
       var basicTemplate = getFixture('Basic.hbs');
 
       stream.on('data', function(newFile) {
+        var expectedString = '{"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {\n  return "Basic template";\n  },"useData":true}';
         should.exist(newFile);
         should.exist(newFile.contents);
-        fileMatchesExpected(newFile, 'Basic.js');
+        should(newFile.contents.toString()).equal(expectedString)
         done();
       });
+
       stream.write(basicTemplate);
       stream.end();
     });

--- a/test/main.js
+++ b/test/main.js
@@ -33,7 +33,7 @@ describe('gulp-emblem', function() {
       var basicTemplate = getFixture('Basic.hbs');
 
       stream.on('data', function(newFile) {
-        var expectedString = '{"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {\n  return "Basic template";\n  },"useData":true}';
+        var expectedString = 'Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {\n  return "Basic template";\n  },"useData":true})';
         should.exist(newFile);
         should.exist(newFile.contents);
         should(newFile.contents.toString()).equal(expectedString)


### PR DESCRIPTION
Upgrades all the dependencies - show stoppers are handlebars 2.0.0 and emblem 0.40.  Fix for https://github.com/buschtoens/gulp-emblem/issues/13

@buschtoens 